### PR TITLE
Fix type error when enumerating SD cards

### DIFF
--- a/VisualDiskImager/Device.cpp
+++ b/VisualDiskImager/Device.cpp
@@ -45,8 +45,11 @@ bool CDevice::Init(IWbemClassObject* disk)
 		VERIFY( SUCCEEDED( model.ChangeType( VT_BSTR ) ) );
 		Model = model;
 
-		VERIFY( SUCCEEDED( type.ChangeType( VT_BSTR ) ) );
-		Type = type;
+		if ( type.vt == VT_BSTR )
+		{
+			VERIFY( SUCCEEDED( type.ChangeType( VT_BSTR ) ) );
+			Type = type;
+		}
 
 		if ( Open( false ) )
 		{


### PR DESCRIPTION
SD cards seems to return no "InterfaceType", hence the `type` may be `VT_NULL`

Fixes: #1